### PR TITLE
Update API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,26 +114,12 @@ You can create sensor with metrics using optional Json object to request content
 
     HTTP/1.1 201 Created
     Content:
-    {
-        "sensorId": "London-5",
-        "datedSensorParams": {
-            "temperature": {
-                "avg": 20.0,
-                "sum": 20.0,
-                "count": 1
-            },
-            "humidity": {
-                "avg": 70.0,
-                "sum": 70.0,
-                "count": 1
-            },
-            "wind": {
-                "avg": 4.0,
-                "sum": 4.0,
-                "count": 1
-            }
-        }
-    }
+    [{
+        "date": "2022-10-14",
+        "temperature": 20.0,
+        "humidity": 0.0,
+        "wind": 0.0
+    }]
 
 Returns `409 Conflict` in case `sensorID` already exists
 
@@ -165,29 +151,15 @@ In case metrics for this date exists, service will compute new average values us
 
 ### Request
 
-    curl --location --request PUT 'http://localhost:8080/v1/data/London-1' --header 'Content-Type: application/json' --data-raw '{"sensorMetrics": [{"date": "2022-10-16","temperature": 0}]}'
+    curl --location --request PUT 'http://localhost:8080/v1/data/London-1' --header 'Content-Type: application/json' --data-raw '{"sensorMetrics": [{"date": "2022-10-16","temperature": 20,"humidity": 70, "wind": 4}]}'
 
 ### Response
 
     HTTP/1.1 200 OK
     Content:
-    {
-        "sensorId": "London-5",
-        "datedSensorParams": {
-            "temperature": {
-                "avg": 20.0,
-                "sum": 20.0,
-                "count": 1
-            },
-            "humidity": {
-                "avg": 0.0,
-                "sum": 0.0,
-                "count": 0
-            },
-            "wind": {
-                "avg": 0.0,
-                "sum": 0.0,
-                "count": 0
-            }
-        }
-    }
+    [{
+        "date": "2022-10-14",
+        "temperature": 20.0,
+        "humidity": 10.0,
+        "wind": 4.0
+    }]

--- a/src/integrationTest/java/com/eugene/weather/AddWeatherDataIT.java
+++ b/src/integrationTest/java/com/eugene/weather/AddWeatherDataIT.java
@@ -16,8 +16,7 @@ public class AddWeatherDataIT extends BaseSpringIT {
     void addsSensorDataById() throws Exception {
         mockMvc.perform(post("/v1/data/London-1")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.sensorId").value("London-1"));
+                .andExpect(status().isCreated());
     }
 
     @Test
@@ -49,14 +48,12 @@ public class AddWeatherDataIT extends BaseSpringIT {
                         .content(getSensorMetricsAsJsonString(Map.of(
                                 "date", "2022-10-14",
                                 "temperature", "20",
-                                "humidity", "60"))))
+                                "humidity", "60",
+                                "wind", "4"))))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.sensorId").value("London-1"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-10-14.temperature.avg").value("20.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-10-14.temperature.sum").value("20.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-10-14.temperature.count").value("1"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-10-14.humidity.avg").value("60.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-10-14.humidity.sum").value("60.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-10-14.humidity.count").value("1"));
+                .andExpect(jsonPath("$[0].date").value("2022-10-14"))
+                .andExpect(jsonPath("$[0].temperature").value("20.0"))
+                .andExpect(jsonPath("$[0].humidity").value("60.0"))
+                .andExpect(jsonPath("$[0].wind").value("4.0"));
     }
 }

--- a/src/integrationTest/java/com/eugene/weather/AddWeatherDataIT.java
+++ b/src/integrationTest/java/com/eugene/weather/AddWeatherDataIT.java
@@ -42,6 +42,15 @@ public class AddWeatherDataIT extends BaseSpringIT {
     }
 
     @Test
+    void returnsBadRequestWhenSensorBodyIsNotComplete() throws Exception {
+        mockMvc.perform(post("/v1/data/London-1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(getSensorMetricsAsJsonString(Map.of(
+                                "date", "2022-10-14"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void addsSensorDataWithBody() throws Exception {
         mockMvc.perform(post("/v1/data/London-1")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/integrationTest/java/com/eugene/weather/UpdateWeatherDataIT.java
+++ b/src/integrationTest/java/com/eugene/weather/UpdateWeatherDataIT.java
@@ -23,8 +23,10 @@ public class UpdateWeatherDataIT extends BaseSpringIT {
     void returnsNotFoundWhenThereIsNoSensorIdInDatabase() throws Exception {
         mockMvc.perform(put("/v1/data/do-not-exist")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(getSensorMetricsAsJsonString(Map.of("date", "2022-01-01"
-                                , "temperature", "22"))))
+                        .content(getSensorMetricsAsJsonString(Map.of("date", "2022-01-01",
+                                "temperature", "22",
+                                "humidity", "60",
+                                "wind", "4"))))
                 .andExpect(status().isNotFound())
                 .andExpect(content().string("There is no sensor with id: do-not-exist"));
     }

--- a/src/integrationTest/java/com/eugene/weather/UpdateWeatherDataIT.java
+++ b/src/integrationTest/java/com/eugene/weather/UpdateWeatherDataIT.java
@@ -35,20 +35,25 @@ public class UpdateWeatherDataIT extends BaseSpringIT {
         sendPostRequestToCreate(sensorId, getSensorMetricsAsJsonString((Map.of(
                 "date", "2022-01-01",
                 "temperature", "15",
-                "humidity", "50"))));
+                "humidity", "50",
+                "wind", "0"))));
 
         mockMvc.perform(put(buildUriWith(sensorId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(getSensorMetricsAsJsonString(Map.of(
-                                "date", "2022-01-02"
-                                , "temperature", "20",
-                                "humidity", "60"))))
+                                "date", "2022-01-02",
+                                "temperature", "20",
+                                "humidity", "60",
+                                "wind", "4"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.sensorId").value("London-1"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.temperature.avg").value("15.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.humidity.avg").value("50.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-02.temperature.avg").value("20.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-02.humidity.avg").value("60.0"));
+                .andExpect(jsonPath("$[0].date").value("2022-01-01"))
+                .andExpect(jsonPath("$[0].temperature").value("15.0"))
+                .andExpect(jsonPath("$[0].humidity").value("50.0"))
+                .andExpect(jsonPath("$[0].wind").value("0.0"))
+                .andExpect(jsonPath("$[1].date").value("2022-01-02"))
+                .andExpect(jsonPath("$[1].temperature").value("20.0"))
+                .andExpect(jsonPath("$[1].humidity").value("60.0"))
+                .andExpect(jsonPath("$[1].wind").value("4.0"));
 
     }
 
@@ -59,21 +64,20 @@ public class UpdateWeatherDataIT extends BaseSpringIT {
         sendPostRequestToCreate(sensorId, getSensorMetricsAsJsonString(Map.of(
                 "date", "2022-01-01",
                 "temperature", "20",
-                "humidity", "50")));
+                "humidity", "50",
+                "wind", "4")));
 
         mockMvc.perform(put(buildUriWith(sensorId))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(getSensorMetricsAsJsonString(Map.of(
                                 "date", "2022-01-01",
                                 "temperature", "10",
-                                "humidity", "60"))))
+                                "humidity", "60",
+                                "wind", "6"))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.sensorId").value("London-1"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.temperature.avg").value("15.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.temperature.sum").value("30.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.temperature.count").value("2"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.humidity.avg").value("55.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.humidity.sum").value("110.0"))
-                .andExpect(jsonPath("$.datedSensorParams.2022-01-01.humidity.count").value("2"));
+                .andExpect(jsonPath("$[0].date").value("2022-01-01"))
+                .andExpect(jsonPath("$[0].temperature").value("15.0"))
+                .andExpect(jsonPath("$[0].humidity").value("55.0"))
+                .andExpect(jsonPath("$[0].wind").value("5.0"));
     }
 }

--- a/src/main/java/com/eugene/weather/controller/WeatherApiController.java
+++ b/src/main/java/com/eugene/weather/controller/WeatherApiController.java
@@ -1,8 +1,9 @@
 package com.eugene.weather.controller;
 
+import com.eugene.weather.controller.data.DatedSensorMetrics;
 import com.eugene.weather.controller.data.FramedSensorMetrics;
 import com.eugene.weather.controller.data.SensorMetrics;
-import com.eugene.weather.repository.data.SensorData;
+import com.eugene.weather.controller.data.WeatherMetrics;
 import com.eugene.weather.service.WeatherAggregationService;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -24,10 +25,10 @@ public class WeatherApiController {
     @GetMapping(path = "/data/all",
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<FramedSensorMetrics> getAllSensorsData(
-                                                             @RequestParam(value = "from", required = false)
-                                                             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
-                                                             @RequestParam(value = "to", required = false)
-                                                             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
+            @RequestParam(value = "from", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(value = "to", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
         startDate = getDefaultIfNull(startDate, () -> LocalDate.EPOCH);
         endDate = getDefaultIfNull(endDate, LocalDate::now);
         return ResponseEntity.ok(weatherAggregationService.getAllSensorsData(startDate, endDate));
@@ -48,8 +49,8 @@ public class WeatherApiController {
     @PostMapping(path = "/data/{sensorId}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<SensorData> addNewSensor(@PathVariable String sensorId,
-                                                   @RequestBody(required = false) SensorMetrics sensorMetrics) {
+    public ResponseEntity<List<DatedSensorMetrics>> addNewSensor(@PathVariable String sensorId,
+                                                       @RequestBody(required = false) SensorMetrics sensorMetrics) {
         sensorMetrics = getDefaultIfNull(sensorMetrics, () -> new SensorMetrics(List.of()));
         return ResponseEntity.status(HttpStatus.CREATED).body(weatherAggregationService.addSensorData(sensorId, sensorMetrics));
     }
@@ -61,8 +62,8 @@ public class WeatherApiController {
     @PutMapping(path = "/data/{sensorId}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<SensorData> updateSensorData(@PathVariable String sensorId,
-                                                       @RequestBody SensorMetrics sensorMetrics) {
+    public ResponseEntity<List<DatedSensorMetrics>> updateSensorData(@PathVariable String sensorId,
+                                                                     @RequestBody SensorMetrics sensorMetrics) {
         return ResponseEntity.ok(weatherAggregationService.updateSensorData(sensorId, sensorMetrics));
     }
 }

--- a/src/main/java/com/eugene/weather/controller/data/DatedSensorMetrics.java
+++ b/src/main/java/com/eugene/weather/controller/data/DatedSensorMetrics.java
@@ -9,7 +9,10 @@ public record DatedSensorMetrics(
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @NonNull
         LocalDate date,
-        double temperature,
-        double humidity,
-        double wind) {
+        @NonNull
+        Double temperature,
+        @NonNull
+        Double humidity,
+        @NonNull
+        Double wind) {
 }

--- a/src/main/java/com/eugene/weather/controller/data/DatedSensorMetrics.java
+++ b/src/main/java/com/eugene/weather/controller/data/DatedSensorMetrics.java
@@ -9,7 +9,7 @@ public record DatedSensorMetrics(
         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
         @NonNull
         LocalDate date,
-        int temperature,
-        int humidity,
-        int wind) {
+        double temperature,
+        double humidity,
+        double wind) {
 }

--- a/src/main/java/com/eugene/weather/mapper/MetricsMapper.java
+++ b/src/main/java/com/eugene/weather/mapper/MetricsMapper.java
@@ -1,14 +1,32 @@
 package com.eugene.weather.mapper;
 
+import com.eugene.weather.controller.data.DatedSensorMetrics;
 import com.eugene.weather.repository.data.AverageData;
+import com.eugene.weather.repository.data.SensorData;
 import com.eugene.weather.repository.data.SensorDayData;
 import com.eugene.weather.service.Average;
 import com.eugene.weather.service.AverageMetrics;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Component
 public class MetricsMapper {
 
+    public List<DatedSensorMetrics> mapToWeatherMetrics(SensorData updatedSensorData) {
+        if (updatedSensorData == null){
+            return List.of();
+        }
+        return updatedSensorData.datedSensorParams().entrySet()
+                .stream()
+                .map(entry -> new DatedSensorMetrics(
+                        LocalDate.parse(entry.getKey()),
+                        entry.getValue().temperature().avg(),
+                        entry.getValue().humidity().avg(),
+                        entry.getValue().wind().avg()))
+                .toList();
+    }
 
     public AverageMetrics mapToAverageMetrics(SensorDayData data) {
         return new AverageMetrics(new Average(data.temperature().sum(), data.temperature().count()),

--- a/src/main/java/com/eugene/weather/service/WeatherAggregationService.java
+++ b/src/main/java/com/eugene/weather/service/WeatherAggregationService.java
@@ -70,21 +70,23 @@ public class WeatherAggregationService {
         }
     }
 
-    public SensorData addSensorData(String sensorId, SensorMetrics sensorMetrics) {
+    public List<DatedSensorMetrics> addSensorData(String sensorId, SensorMetrics sensorMetrics) {
         SensorData sensorData = new SensorData(sensorId, aggregateMetricsToAverageParams(sensorMetrics.sensorMetrics()));
-        return sensorRepository.addSensorData(sensorData);
+        SensorData newSensorData = sensorRepository.addSensorData(sensorData);
+        return mapper.mapToWeatherMetrics(newSensorData);
     }
 
-    public SensorData updateSensorData(String sensorId, @NonNull SensorMetrics sensorMetrics) {
+    public List<DatedSensorMetrics> updateSensorData(String sensorId, @NonNull SensorMetrics sensorMetrics) {
         SensorData oldSensorData = sensorRepository.getSensorData(sensorId);
         throwNotFoundExceptionIfNull(sensorId, oldSensorData);
         if (sensorMetrics.sensorMetrics().isEmpty()) {
-            return oldSensorData;
+            return mapper.mapToWeatherMetrics(oldSensorData);
         }
         var oldDataParams = oldSensorData.datedSensorParams();
         var newDataParams = aggregateMetricsToAverageParams(sensorMetrics.sensorMetrics());
         var datedSensorParams = mergeDayDataParameters(oldDataParams, newDataParams);
-        return sensorRepository.updateSensorData(new SensorData(sensorId, datedSensorParams));
+        SensorData updatedSensorData = sensorRepository.updateSensorData(new SensorData(sensorId, datedSensorParams));
+        return mapper.mapToWeatherMetrics(updatedSensorData);
     }
 
     private Map<String, SensorDayData> aggregateMetricsToAverageParams(List<DatedSensorMetrics> sensorMetrics) {
@@ -95,7 +97,7 @@ public class WeatherAggregationService {
                         sm -> new AverageMetrics(
                                 new Average(sm.temperature(), 1),
                                 new Average(sm.humidity(), 1),
-                                new Average(sm.wind(),1)),
+                                new Average(sm.wind(), 1)),
                         AverageMetrics::plus))
                 .entrySet()
                 .stream()

--- a/src/test/java/com/eugene/weather/AddWeatherAggregationServiceTest.java
+++ b/src/test/java/com/eugene/weather/AddWeatherAggregationServiceTest.java
@@ -23,11 +23,11 @@ class AddWeatherAggregationServiceTest extends BaseTest {
 
     @Test
     void testAddAggregatesTwoMetricsInDay() {
-        int firstTemperature = 10;
-        int secondTemperature = 20;
+        double firstTemperature = 10;
+        double secondTemperature = 20;
         List<DatedSensorMetrics> twoMetricsForDay =
-                List.of(new DatedSensorMetrics(DATE, firstTemperature, 0,0)
-                        ,new DatedSensorMetrics(DATE, secondTemperature, 0,0));
+                List.of(new DatedSensorMetrics(DATE, firstTemperature, 0.0,0.0),
+                        new DatedSensorMetrics(DATE, secondTemperature, 0.0,0.0));
 
         sut.addSensorData("testId", new SensorMetrics(twoMetricsForDay));
 
@@ -38,11 +38,11 @@ class AddWeatherAggregationServiceTest extends BaseTest {
 
     @Test
     void testAddDoesNotAggregateMetricsForDifferentDates() {
-        int firstTemperature = 10;
-        int secondTemperature = 20;
+        double firstTemperature = 10;
+        double secondTemperature = 20;
         List<DatedSensorMetrics> twoMetricsForDifferentDays =
-                List.of(new DatedSensorMetrics(DATE, firstTemperature, 0,0)
-                        , new DatedSensorMetrics(NEXT_DATE, secondTemperature, 0,0));
+                List.of(new DatedSensorMetrics(DATE, firstTemperature, 0.0,0.0)
+                        , new DatedSensorMetrics(NEXT_DATE, secondTemperature, 0.0,0.0));
 
         sut.addSensorData("testId", new SensorMetrics(twoMetricsForDifferentDays));
 

--- a/src/test/java/com/eugene/weather/UpdateWeatherAggregationServiceTest.java
+++ b/src/test/java/com/eugene/weather/UpdateWeatherAggregationServiceTest.java
@@ -19,10 +19,10 @@ class UpdateWeatherAggregationServiceTest extends BaseTest {
 
     @Test
     void testUpdatesEmptyParametersWithNewMetrics() {
-        int newTemperature = 10;
+        double newTemperature = 10;
         String id = "testId";
         List<DatedSensorMetrics> newMetrics =
-                List.of(new DatedSensorMetrics(DATE, newTemperature, 0,0));
+                List.of(new DatedSensorMetrics(DATE, newTemperature, 0.0,0.0));
         mockRepositoryGetSensorData(id, Map.of());
 
         sut.updateSensorData(id, new SensorMetrics(newMetrics));
@@ -54,7 +54,7 @@ class UpdateWeatherAggregationServiceTest extends BaseTest {
         mockRepositoryGetSensorData(null, null);
 
         List<DatedSensorMetrics> newMetrics =
-                List.of(new DatedSensorMetrics(DATE, 10, 0,0));
+                List.of(new DatedSensorMetrics(DATE, 10.0, 0.0,0.0));
 
 
         assertThrows(SensorNotFoundException.class,
@@ -70,7 +70,7 @@ class UpdateWeatherAggregationServiceTest extends BaseTest {
         Map<String, SensorDayData> oldMetrics = Map.of(DATE.toString(), oldTemperature);
         mockRepositoryGetSensorData(id, oldMetrics);
 
-        DatedSensorMetrics newTemperature = new DatedSensorMetrics(DATE, 20, 0,0);
+        DatedSensorMetrics newTemperature = new DatedSensorMetrics(DATE, 20.0, 0.0,0.0);
         List<DatedSensorMetrics> newMetrics = List.of(newTemperature);
 
         sut.updateSensorData(id, new SensorMetrics(newMetrics));

--- a/src/test/java/com/eugene/weather/UpdateWeatherAggregationServiceTest.java
+++ b/src/test/java/com/eugene/weather/UpdateWeatherAggregationServiceTest.java
@@ -39,10 +39,13 @@ class UpdateWeatherAggregationServiceTest extends BaseTest {
         mockRepositoryGetSensorData(id, Map.of(DATE.toString(), oldData));
         List<DatedSensorMetrics> newEmptyMetrics = List.of();
 
-        SensorData result = sut.updateSensorData(id, new SensorMetrics(newEmptyMetrics));
+        List<DatedSensorMetrics> result = sut.updateSensorData(id, new SensorMetrics(newEmptyMetrics));
 
-        SensorDayData resultData = result.datedSensorParams().get(DATE.toString());
-        assertEquals(oldData, resultData);
+        assertEquals(1,result.size());
+        DatedSensorMetrics resultData = result.get(0);
+        assertEquals(oldData.temperature().avg(), resultData.temperature());
+        assertEquals(oldData.humidity().avg(), resultData.humidity());
+        assertEquals(oldData.wind().avg(), resultData.wind());
         verify(repositoryMock, never()).updateSensorData(any());
     }
 


### PR DESCRIPTION
Reduced amount of parameters exposed to client
old create/update response body 
`{
        "sensorId": "London-5",
        "datedSensorParams": {
            "temperature": {
                "avg": 20.0,
                "sum": 20.0,
                "count": 1
            },
            "humidity": {
                "avg": 0.0,
                "sum": 0.0,
                "count": 0
            },
            "wind": {
                "avg": 0.0,
                "sum": 0.0,
                "count": 0
            }
        }
    }`

new response body 
  `  [{
        "date": "2022-10-14",
        "temperature": 20.0,
        "humidity": 10.0,
        "wind": 4.0
    }]`